### PR TITLE
Fix winapi imports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,11 @@ name = "spoticli"
 path = "src/bin/spoticli.rs"
 
 [dependencies]
-winapi = "0.3.9"
+json = "0.12.4"
 kernel32-sys = "0.2.2"
 reqwest = "0.9"
-json = "0.12.4"
 time = "0.1"
+winapi = { version = "0.3.9", features = ["tlhelp32"] }
 
 [build-dependencies]
 skeptic = "0.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ path = "src/bin/spoticli.rs"
 
 [dependencies]
 json = "0.12.4"
-kernel32-sys = "0.2.2"
 reqwest = "0.9"
 time = "0.1"
 winapi = { version = "0.3.9", features = ["tlhelp32"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@
 
 // Extern crates
 extern crate json;
-extern crate kernel32;
 extern crate reqwest;
 extern crate time;
 extern crate winapi;

--- a/src/windows_process.rs
+++ b/src/windows_process.rs
@@ -1,11 +1,13 @@
 #![cfg(windows)]
 
-use kernel32::{CreateToolhelp32Snapshot, OpenProcess, Process32First, Process32Next};
 use std::cmp::Ordering;
 use std::ffi::{CStr, CString};
 use std::mem::{size_of, zeroed};
 use winapi::shared::minwindef::{DWORD, FALSE, TRUE};
-use winapi::um::tlhelp32::{PROCESSENTRY32, TH32CS_SNAPPROCESS};
+use winapi::um::processthreadsapi::OpenProcess;
+use winapi::um::tlhelp32::{
+    CreateToolhelp32Snapshot, Process32First, Process32Next, PROCESSENTRY32, TH32CS_SNAPPROCESS,
+};
 use winapi::um::winnt::{HANDLE, PROCESS_ALL_ACCESS};
 
 /// The `WindowsProcess` struct.

--- a/src/windows_process.rs
+++ b/src/windows_process.rs
@@ -4,9 +4,9 @@ use kernel32::{CreateToolhelp32Snapshot, OpenProcess, Process32First, Process32N
 use std::cmp::Ordering;
 use std::ffi::{CStr, CString};
 use std::mem::{size_of, zeroed};
-use winapi::minwindef::{DWORD, FALSE, TRUE};
-use winapi::tlhelp32::{PROCESSENTRY32, TH32CS_SNAPPROCESS};
-use winapi::winnt::{HANDLE, PROCESS_ALL_ACCESS};
+use winapi::shared::minwindef::{DWORD, FALSE, TRUE};
+use winapi::um::tlhelp32::{PROCESSENTRY32, TH32CS_SNAPPROCESS};
+use winapi::um::winnt::{HANDLE, PROCESS_ALL_ACCESS};
 
 /// The `WindowsProcess` struct.
 #[derive(Clone)]


### PR DESCRIPTION
The library compiles and "works" if you run a dummy process named `SpotifyWebHelper.exe`, but it seems Spotify no longer spawns this process, so this library doesn't appear to work anymore :(

Fixes #5 